### PR TITLE
Automate Nginx Proxy Manager and Pihole initial configuration

### DIFF
--- a/core-apps/compose.yaml
+++ b/core-apps/compose.yaml
@@ -1,37 +1,23 @@
 # Core infrastructure stack: Pi-hole, Nginx Proxy Manager & Portainer
 services:
-  pihole-init:
-    image: alpine:3.20
-    container_name: pihole-init
-    command: >
-      sh -c "
-        apk add --no-cache bash &&
-        echo '${HOST_IP} main.lan' > /etc/pihole/custom.list &&
-        echo 'cname=pihole.main.lan,main.lan' >> /etc/pihole/custom.list &&
-        echo 'cname=npm.main.lan,main.lan' >> /etc/pihole/custom.list &&
-        echo 'cname=portainer.main.lan,main.lan' >> /etc/pihole/custom.list
-      "
-    volumes:
-      - pihole_data:/etc/pihole
-    environment:
-      HOST_IP: ${HOST_IP}
-    networks:
-      - dns
-    restart: "no"
-
   pihole:
     image: pihole/pihole:2025.06.2
     container_name: pihole
     restart: unless-stopped
-    # DNS ports (TCP & UDP) and DHCP
     ports:
       - "53:53/tcp"
       - "53:53/udp"
       - "67:67/udp"
     environment:
-      TZ: 'Asia/Kolkata'         
+      TZ: 'Asia/Kolkata'
       FTLCONF_webserver_api_password: '${PIHOLE_PASS}'
       FTLCONF_dns_listeningMode: all
+      FTLCONF_dns_hosts: |
+        ${HOST_IP} main.lan
+      FTLCONF_dns_cnameRecords: |
+        portainer.home.lan,main.lan
+        npm.home.lan,main.lan
+        pihole.home.lan,main.lan
     volumes:
       - pihole_data:/etc/pihole
     networks:
@@ -47,8 +33,8 @@ services:
       - "443:443"     # HTTPS proxy
       - "81:81"       # Admin UI
     environment:
-      INITIAL_ADMIN_EMAIL: '${NPM_USER}'
-      INITIAL_ADMIN_PASSWORD: '${NPM_PASS}'
+      INITIAL_ADMIN_EMAIL: ${NPM_USER}
+      INITIAL_ADMIN_PASSWORD: ${NPM_PASS}
     volumes:
       - npm_data:/data
       - npm_letsencrypt:/etc/letsencrypt
@@ -78,8 +64,8 @@ services:
     volumes:
       - ./npm-init/init-proxy-hosts.sh:/init-proxy-hosts.sh:ro
     environment:
-      NPM_USER: '${NPM_USER}'
-      NPM_PASS: '${NPM_PASS}'
+      NPM_USER: ${NPM_USER}
+      NPM_PASS: ${NPM_PASS}
     command: >
       sh -c "apk add --no-cache curl jq && sh /init-proxy-hosts.sh"
     networks:

--- a/core-apps/pihole-config/05-pihole-custom-cname.conf
+++ b/core-apps/pihole-config/05-pihole-custom-cname.conf
@@ -1,3 +1,0 @@
-cname=pihole.home.lan,main.lan
-cname=npm.home.lan,main.lan
-cname=portainer.home.lan,main.lan

--- a/core-apps/pihole-config/custom.list
+++ b/core-apps/pihole-config/custom.list
@@ -1,1 +1,0 @@
-YOUR_IP_ADDRESS_HERE main.lan


### PR DESCRIPTION
## Summary
The initial proxy host creation for Nginx Proxy Manager (NPM) and DNS records and CNAME records creation for Pihole has now been automated. Includes other fixes as well.

## Changes
### compose.yaml
File path: `core-apps/compose.yaml`
- Automated proxy host record creation for NPM.
- Automated DNS records and CNAME records creation for Pihole.
- Secrets moved completely to `.env` files.
- Move to using Named volumes and Name Docker network.
- Added a post-job `npm-init` that runs after NPM container has fully started which creates the required NPM proxy host records.

### init-proxy-hosts.sh
File path: `core-apps/npm-init/init-proxy-hosts.sh`
- New script added: Uses NPM REST API to create the required initial NPM proxy host records.