### PR TITLE
Add Homepage app to stack 1

### DIFF
--- a/core-apps/compose.yaml
+++ b/core-apps/compose.yaml
@@ -18,6 +18,7 @@ services:
         portainer.home.lan,main.lan
         npm.home.lan,main.lan
         pihole.home.lan,main.lan
+        home.lan,main.lan
     volumes:
       - pihole_data:/etc/pihole
     networks:
@@ -41,6 +42,11 @@ services:
     networks:
       - proxy
       - dns
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:81/api/"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   portainer:
     image: portainer/portainer-ce:lts
@@ -60,7 +66,8 @@ services:
     image: alpine:3.20
     container_name: npm-init
     depends_on:
-      - nginx-proxy-manager
+      nginx-proxy-manager:
+        condition: service_healthy
     volumes:
       - ./npm-init/init-proxy-hosts.sh:/init-proxy-hosts.sh:ro
     environment:

--- a/core-apps/npm-init/init-proxy-hosts.sh
+++ b/core-apps/npm-init/init-proxy-hosts.sh
@@ -1,18 +1,31 @@
 #!/bin/sh
 set -e
 
-echo "Waiting for NPM API..."
-until curl -s http://nginx-proxy-manager:81/api/ > /dev/null; do
+echo "Waiting for NPM API (max 60 seconds)..."
+i=0
+while [ $i -lt 12 ]; do
+  if curl -s http://nginx-proxy-manager:81/api/ > /dev/null; then
+    echo "NPM API is up!"
+    break
+  fi
+  echo "Waiting... ($i/12)"
   sleep 5
+  i=$((i + 1))
 done
 
+if [ $i -eq 12 ]; then
+  echo "Failed to connect to NPM API after 60 seconds"
+  exit 1
+fi
+
 echo "Logging into NPM..."
-TOKEN=$(curl -s -X POST http://nginx-proxy-manager:81/api/tokens \
+RESPONSE=$(curl -s -X POST http://nginx-proxy-manager:81/api/tokens \
   -H "Content-Type: application/json" \
-  -d '{"identity":"'"$NPM_USER"'","secret":"'"$NPM_PASS"'"}' | jq -r .token)
+  -d '{"identity":"'"$NPM_USER"'","secret":"'"$NPM_PASS"'"}')
+TOKEN=$(echo "$RESPONSE" | jq -r .token)
 
 if [ "$TOKEN" = "null" ] || [ -z "$TOKEN" ]; then
-  echo "Failed to log into NPM API"
+  echo "Failed to log into NPM API. Response: $RESPONSE"
   exit 1
 fi
 
@@ -42,6 +55,7 @@ create_proxy_host() {
     }' > /dev/null
 }
 
+create_proxy_host "home.lan" "homepage" 3000
 create_proxy_host "pihole.home.lan" "pihole" 80
 create_proxy_host "npm.home.lan" "nginx-proxy-manager" 81
 create_proxy_host "portainer.home.lan" "portainer" 9000

--- a/stack-1/compose.yml
+++ b/stack-1/compose.yml
@@ -10,7 +10,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./resources/thehomepage-custom-images:/app/public/images:ro
     environment:
-      HOMEPAGE_ALLOWED_HOSTS: localhost,127.0.0.1,${HOST_IP},home-server.apps,home.lan
+      HOMEPAGE_ALLOWED_HOSTS: localhost,127.0.0.1,${HOST_IP},homepage,home.lan
     networks:
       - home-server
       - proxy


### PR DESCRIPTION
## Summary
Added Homepage to stack-1 with other fixes.

## Changes
### compose.yaml
File path: `core-apps/compose.yaml`
- Add health-check to Nginx Proxy Manager
- Make `npm-init` wait till the `nginx-proxy-manager` container is fully up along with its API endpoint.

### init-proxy-hosts.sh
File path: `core-apps/npm-init/init-proxy-hosts.sh`
- Fix syntax errors.
- Updated logic to check whether the Nginx Proxy Manager API is up.

### compose.yml
File path: `stack-1/compose.yml`
- Added app Hompage to stack-1.