### PR TITLE
Add Homepage and Gitea

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/.env
 stack-1/data/
+stack-1/resources/homepage/config/logs

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 **/.env
+stack-1/data/

--- a/core-apps/compose.yaml
+++ b/core-apps/compose.yaml
@@ -19,6 +19,7 @@ services:
         npm.home.lan,main.lan
         pihole.home.lan,main.lan
         home.lan,main.lan
+        gitea.home.lan,main.lan
     volumes:
       - pihole_data:/etc/pihole
     networks:

--- a/core-apps/npm-init/init-proxy-hosts.sh
+++ b/core-apps/npm-init/init-proxy-hosts.sh
@@ -59,5 +59,6 @@ create_proxy_host "home.lan" "homepage" 3000
 create_proxy_host "pihole.home.lan" "pihole" 80
 create_proxy_host "npm.home.lan" "nginx-proxy-manager" 81
 create_proxy_host "portainer.home.lan" "portainer" 9000
+create_proxy_host "gitea.home.lan" "gitea" 3000
 
 echo "Proxy hosts created successfully!"

--- a/stack-1/compose.yml
+++ b/stack-1/compose.yml
@@ -6,25 +6,55 @@ services:
     expose:
       - "3000"
     volumes:
-      - homepage_config:/app/config
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - ./resources/thehomepage-custom-images:/app/public/images:ro
+      - ./resources/homepage/config:/app/config
+      - ./resources/homepage/custom-images:/app/public/images:ro
     environment:
       HOMEPAGE_ALLOWED_HOSTS: localhost,127.0.0.1,${HOST_IP},homepage,home.lan
     networks:
       - home-server
       - proxy
+  gitea:
+    image: docker.gitea.com/gitea:1.24.6
+    container_name: gitea
+    depends_on:
+      - postgres
+    restart: unless-stopped
+    expose:
+      - "3000"
+    volumes:
+      - ./data/gitea:/data
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    environment:
+      - GITEA__database__DB_TYPE=postgres
+      - GITEA__database__HOST=postgres:5432
+      - GITEA__database__NAME=gitea
+      - GITEA__database__USER=${GITEA_DB_USER}
+      - GITEA__database__PASSWD=${GITEA_DB_PWD}
+    networks:
+      - gitea
+      - proxy
+  postgres:
+    image: docker.io/library/postgres:14
+    container_name: postgres
+    restart: unless-stopped
+    environment:
+      - POSTGRES_USER=${GITEA_DB_USER}
+      - POSTGRES_PASSWORD=${GITEA_DB_PWD}
+      - POSTGRES_DB=gitea
+    networks:
+      - gitea
+    volumes:
+      - ./data/postgres:/var/lib/postgresql/data
 
 networks:
   home-server:
     name: home-server
-    driver: bridge
+    external: true
   proxy:
     name: proxy
-    driver: bridge
-
-volumes:
-  homepage_config:
-    name: homepage_config
-  homepage_images:
-    name: homepage_images
+    external: true
+  gitea:
+    name: gitea
+    external: false

--- a/stack-1/resources/homepage/config/bookmarks.yaml
+++ b/stack-1/resources/homepage/config/bookmarks.yaml
@@ -1,0 +1,18 @@
+---
+# For configuration options and examples, please see:
+# https://gethomepage.dev/configs/bookmarks
+
+- Developer:
+    - Github:
+        - abbr: GH
+          href: https://github.com/
+
+- Social:
+    - Reddit:
+        - abbr: RE
+          href: https://reddit.com/
+
+- Entertainment:
+    - YouTube:
+        - abbr: YT
+          href: https://youtube.com/

--- a/stack-1/resources/homepage/config/docker.yaml
+++ b/stack-1/resources/homepage/config/docker.yaml
@@ -1,0 +1,10 @@
+---
+# For configuration options and examples, please see:
+# https://gethomepage.dev/configs/docker/
+
+# my-docker:
+#   host: 127.0.0.1
+#   port: 2375
+
+# my-docker:
+#   socket: /var/run/docker.sock

--- a/stack-1/resources/homepage/config/kubernetes.yaml
+++ b/stack-1/resources/homepage/config/kubernetes.yaml
@@ -1,0 +1,2 @@
+---
+# sample kubernetes config

--- a/stack-1/resources/homepage/config/logs/homepage.log
+++ b/stack-1/resources/homepage/config/logs/homepage.log
@@ -1,7 +1,0 @@
-[2025-09-14T13:41:15.070Z] info: kubernetes.yaml was copied to the config folder
-[2025-09-14T13:41:50.481Z] info: docker.yaml was copied to the config folder
-[2025-09-14T13:41:50.484Z] info: services.yaml was copied to the config folder
-[2025-09-14T13:41:50.486Z] info: bookmarks.yaml was copied to the config folder
-[2025-09-14T13:41:50.516Z] info: widgets.yaml was copied to the config folder
-[2025-09-14T13:41:50.518Z] info: custom.css was copied to the config folder
-[2025-09-14T13:41:50.522Z] info: custom.js was copied to the config folder

--- a/stack-1/resources/homepage/config/logs/homepage.log
+++ b/stack-1/resources/homepage/config/logs/homepage.log
@@ -1,0 +1,7 @@
+[2025-09-14T13:41:15.070Z] info: kubernetes.yaml was copied to the config folder
+[2025-09-14T13:41:50.481Z] info: docker.yaml was copied to the config folder
+[2025-09-14T13:41:50.484Z] info: services.yaml was copied to the config folder
+[2025-09-14T13:41:50.486Z] info: bookmarks.yaml was copied to the config folder
+[2025-09-14T13:41:50.516Z] info: widgets.yaml was copied to the config folder
+[2025-09-14T13:41:50.518Z] info: custom.css was copied to the config folder
+[2025-09-14T13:41:50.522Z] info: custom.js was copied to the config folder

--- a/stack-1/resources/homepage/config/services.yaml
+++ b/stack-1/resources/homepage/config/services.yaml
@@ -1,0 +1,24 @@
+---
+# For configuration options and examples, please see:
+# https://gethomepage.dev/configs/services/
+
+- CORE APPS:
+    - PORTAINER:
+        href: http://portainer.home.lan/
+        description: Monitor and manage your Docker environment.
+    - NGINX PROXY MANAGER:
+        href: http://npm.home.lan/
+        description: Manage reverse proxies, SSL certificates, and domain routing for your services.
+    - PIHOLE:
+        href: http://pihole.home.lan/admin/
+        description: Network-wide DNS sinkhole to block ads and manage local Domain records.
+
+- STACK - 1:
+    - GITEA:
+        href: http://gitea.home.lan/
+        description: A light-weight self-hosted Git based source code management tool.
+
+- My Third Group:
+    - My Third Service:
+        href: http://localhost/
+        description: Homepage is 😎

--- a/stack-1/resources/homepage/config/settings.yaml
+++ b/stack-1/resources/homepage/config/settings.yaml
@@ -1,0 +1,7 @@
+---
+# For configuration options and examples, please see:
+# https://gethomepage.dev/configs/settings/
+
+providers:
+  openweathermap: openweathermapapikey
+  weatherapi: weatherapiapikey

--- a/stack-1/resources/homepage/config/widgets.yaml
+++ b/stack-1/resources/homepage/config/widgets.yaml
@@ -1,0 +1,12 @@
+---
+# For configuration options and examples, please see:
+# https://gethomepage.dev/configs/info-widgets/
+
+- resources:
+    cpu: true
+    memory: true
+    disk: /
+
+- search:
+    provider: duckduckgo
+    target: _blank


### PR DESCRIPTION
## Summary
Added Homepage and Gitea.

## Changes
### compose.yaml
File path: `core-apps/compose.yaml`
- Add domain for Gitea.

### init-proxy-hosts.sh
File path: `core-apps/npm-init/init-proxy-hosts.sh`
- Add proxy host for Gitea.

### compose.yml
File path: `stack-1/compose.yml`
- Add compose config for Homepage.
- Add compose config for Gitea.

### Homepage configs
Directory path: stack-1/resources/homepage/config/*
- Configuration files to customize Homepage.